### PR TITLE
wrapper.cpp에 c++ class wrapping 추가

### DIFF
--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -16,6 +16,11 @@ PYBIND11_MODULE(seal, m)
     m.doc() = "Microsoft SEAL for Python, from https://github.com/Huelse/SEAL-Python";
     m.attr("__version__")  = "4.0.0";
 
+    py::class_<PyBindWrapper>(m, "PyBindWrapper")
+        .def(py::init<>())
+        .def("create_pool", &PyBindWrapper::create_pool)
+        .def("destroy_pool", &PyBindWrapper::destroy_pool)
+
     py::bind_vector<std::vector<double>>(m, "VectorDouble", py::buffer_protocol());
     py::bind_vector<std::vector<std::int64_t>>(m, "VectorInt", py::buffer_protocol());
 

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -18,8 +18,8 @@ PYBIND11_MODULE(seal, m)
 
     py::class_<DesiloCustomMemoryManager>(m, "DesiloCustomMemoryManager")
         .def(py::init<>())
-        .def("initialize_memory_pool", &DesiloCustomMemoryManager::initialize_memory_pool)
-        .def("release_memory_pool", &DesiloCustomMemoryManager::release_memory_pool);
+        .def("create_custom_pool", &DesiloCustomMemoryManager::create_custom_pool)
+        .def("delete_custom_pool", &DesiloCustomMemoryManager::delete_custom_pool);
 
     py::bind_vector<std::vector<double>>(m, "VectorDouble", py::buffer_protocol());
     py::bind_vector<std::vector<std::int64_t>>(m, "VectorInt", py::buffer_protocol());

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -19,7 +19,7 @@ PYBIND11_MODULE(seal, m)
     py::class_<PyBindWrapper>(m, "PyBindWrapper")
         .def(py::init<>())
         .def("create_pool", &PyBindWrapper::create_pool)
-        .def("destroy_pool", &PyBindWrapper::destroy_pool)
+        .def("destroy_pool", &PyBindWrapper::destroy_pool);
 
     py::bind_vector<std::vector<double>>(m, "VectorDouble", py::buffer_protocol());
     py::bind_vector<std::vector<std::int64_t>>(m, "VectorInt", py::buffer_protocol());

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -16,10 +16,10 @@ PYBIND11_MODULE(seal, m)
     m.doc() = "Microsoft SEAL for Python, from https://github.com/Huelse/SEAL-Python";
     m.attr("__version__")  = "4.0.0";
 
-    py::class_<PyBindWrapper>(m, "PyBindWrapper")
+    py::class_<DesiloCustomMemoryManager>(m, "DesiloCustomMemoryManager")
         .def(py::init<>())
-        .def("create_pool", &PyBindWrapper::create_pool)
-        .def("destroy_pool", &PyBindWrapper::destroy_pool);
+        .def("initialize_memory_pool", &DesiloCustomMemoryManager::initialize_memory_pool)
+        .def("release_memory_pool", &DesiloCustomMemoryManager::release_memory_pool);
 
     py::bind_vector<std::vector<double>>(m, "VectorDouble", py::buffer_protocol());
     py::bind_vector<std::vector<std::int64_t>>(m, "VectorInt", py::buffer_protocol());


### PR DESCRIPTION
[#2984](https://github.com/Desilo/HER/issues/2984) 이슈에 따라 multiply 연산 전후로 메모리 릭을 처리하기 위한 custom memorypool을 생성했다 원래의 memorypool로 교체해 줍니다. ([MS SEAL issue](https://github.com/microsoft/SEAL/issues/241#issuecomment-726386665)에서 솔루션으로 제시한 방법)

[SEAL#3](https://github.com/Desilo/SEAL/pull/3)에서 c++ class를 작성했습니다.
이번 PR에선 해당 솔루션을 python에서 적용하기 위한 pybind wrapper를 작성합니다.

