### PR TITLE
update pybind 2.9.1 -> 2.10.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "pybind11>=2.9.1",
+    "pybind11>=2.10.4",
 ]
 
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
python 3.11 지원을 위해 pybind 버전을 올립니다.